### PR TITLE
Fix logos on blogs

### DIFF
--- a/blogs/_posts/2017-06-22-introducing-buildah.html.md
+++ b/blogs/_posts/2017-06-22-introducing-buildah.html.md
@@ -7,6 +7,7 @@ tags: containers, images, docker, buildah, oci
 comments: true
 published: true
 ---
+![buildah logo](https://cdn.rawgit.com/projectatomic/buildah/master/logos/buildah-logo_large.png)
 
 Since I'm relatively new to the world of containers and images, I was excited to learn about [the Buildah tool](https://github.com/projectatomic/buildah).  Especially since I'm a native New Englander and it's a clever play on how we say Builder in these parts.
 

--- a/blogs/_posts/2017-08-07-buildah-getting-fit.html.md
+++ b/blogs/_posts/2017-08-07-buildah-getting-fit.html.md
@@ -7,6 +7,7 @@ tags: buildah, fedora, containers
 comments: false
 published: true
 ---
+![buildah logo](https://cdn.rawgit.com/projectatomic/buildah/master/logos/buildah-logo_large.png)
 
 Like many other Americans, I am fighting the battle to stay fit and I'm not always winning.  Staying fit can also be a problem in the container environment.  A common problem people have with building container images with tools like Dockerfile and the run-time-based [docker build command](https://docs.docker.com/engine/reference/commandline/build/) is the size of the image, as well as the number of build tools that end up inside of it.  Another concern about these unnecessary tools is they can weaken your container by opening potential venues for hackers to take advantage.
 

--- a/blogs/_posts/2017-11-02-getting-started-with-buildah.md
+++ b/blogs/_posts/2017-11-02-getting-started-with-buildah.md
@@ -10,8 +10,7 @@ tags:
 - oci
 - containers
 ---
-
-![Buildah logo](buildah-logo.png)
+![buildah logo](https://cdn.rawgit.com/projectatomic/buildah/master/logos/buildah-logo_large.png)
 
 *Check out the new Buildah project logo.  Isn't it sweet?*
 

--- a/blogs/_posts/2018-01-16-buildah-blocks.html.md
+++ b/blogs/_posts/2018-01-16-buildah-blocks.html.md
@@ -7,6 +7,7 @@ comments: false
 categories: [blogs]
 tags: atomic, buildah, containers
 ---
+![buildah logo](https://cdn.rawgit.com/projectatomic/buildah/master/logos/buildah-logo_large.png)
 
 I’ve always been fascinated by the [three shells and a pea game](https://en.wikipedia.org/wiki/Shell_game) that street hustlers have used for years to make a bit of coin. I love watching a talented person running the game, but I know better than to bet on it! However, playing the game with [Buildah](https://github.com/projectatomic/buildah) leads to everyone being a winner.
 

--- a/blogs/_posts/2018-01-26-using-image-registries-with-buildah.md
+++ b/blogs/_posts/2018-01-26-using-image-registries-with-buildah.md
@@ -8,8 +8,7 @@ comments: false
 categories: [blogs]
 tags: buildah, oci, containers, registry
 ---
-
-![Buildah](/images/buildah-logo.png?1517062481)
+![buildah logo](https://cdn.rawgit.com/projectatomic/buildah/master/logos/buildah-logo_large.png)
 
 # Using Buildah with container registries
 

--- a/blogs/_posts/2018-02-27-buildah-builds-itself.html.md
+++ b/blogs/_posts/2018-02-27-buildah-builds-itself.html.md
@@ -7,6 +7,7 @@ comments: false
 categories: [blogs]
 tags: atomic, buildah, containers
 ---
+![buildah logo](https://cdn.rawgit.com/projectatomic/buildah/master/logos/buildah-logo_large.png)
 
 I’m a fan of Isaac Asimov’s ["Three Laws of Robotics"](https://en.wikipedia.org/wiki/Three_Laws_of_Robotics) and I'm beginning to wonder if these laws need to be wired into [Buildah](https://github.com/projectatomic/buildah). You see Buildah builds itself. It’s self-propagating.
 

--- a/blogs/_posts/2018-03-01-building-buildah-container-image-for-kubernetes.md
+++ b/blogs/_posts/2018-03-01-building-buildah-container-image-for-kubernetes.md
@@ -11,7 +11,6 @@ tags:
 - containers
 - kubernetes
 ---
-
 ![buildah logo](https://cdn.rawgit.com/projectatomic/buildah/master/logos/buildah-logo_large.png)
 
 # Building a Buildah Container Image for Kubernetes


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Some of the blog posts were missing or had bad links to the buildah log, corrected that here.