### PR TITLE
One more index.html tweak

### DIFF
--- a/blogs/index.html
+++ b/blogs/index.html
@@ -9,6 +9,6 @@ title: Buildah Blogs
 
 <section class="posts">
   {% for post in site.categories.blogs %}
-    <p><h3><a href="{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a><h3><br><h4><span>{{ post.date | date_to_string }}</span> by {{ post.author }}</h4></p>
+    <p><h3><a href="{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a><br><span>{{ post.date | date_to_string }}</span> by {{ post.author }}</h3></p>
   {% endfor %}
 </section>


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

The last "fix" to add a carriage return after the blog title also added some unintended ruler's and extra space due to a coding error and the css that's in play.  Hoping this change will fix things the way I originally intended.  This is only for the buildah.io/blogs page, once all happy, will move to do the podman.io/blogs index also.