### PR TITLE
Fix author github and twitter tags

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,22 +21,22 @@ authors:
     gravatar:  
     email: dwalsh@redhat.com
     web: https://redhat.com
-    twitter: @rhatdan
-    github: @rhatdan
+    twitter: rhatdan
+    github: rhatdan
   ipbabble:
     name: William Henry
     display_name: ipbabble
     gravatar: 
     email: whenry@redhat.com
     web: https://redhat.com
-    twitter: @ipbabble
-    github: @ipbabble
+    twitter: ipbabble
+    github: ipbabble
   tsweeney:
     name: Tom Sweeney 
     display_name: Tom Sweeney
     gravatar: c69c8419c8e4d1bbedc7874281453781 
     email: tsweeney@redhat.com
     web: https://redhat.com
-    twitter: @TSweeneyRedHat
-    github: @tomsweeneyredhat
+    twitter: TSweeneyRedHat
+    github: tomsweeneyredhat
 


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Remove @ from github and twitter handles