### PR TITLE
Remove confusing RHBlog link

### DIFF
--- a/_posts/2019-04-16-cinc.md
+++ b/_posts/2019-04-16-cinc.md
@@ -12,4 +12,4 @@ tags: containers, images, docker, buildah, podman, oci
 # Build and run Buildah inside a Podman container
 ## By {{ author.display_name }} [GitHub](https://github.com/{{ author.github }}) [Twitter](https://twitter.com/{{ author.twitter }})
 
-What happens when you combine [Matryoshka Dolls](https://en.wikipedia.org/wiki/Matryoshka_doll) with containers?  Why you get containers in containers in containers!  Read all about it with this new article on the [Red Hat Developer Blog](https://developers.redhat.com/blog/): [Build and run Buildah inside a Podman container](https://developers.redhat.com/blog/2019/04/04/build-and-run-buildah-inside-a-podman-container/).
+What happens when you combine [Matryoshka Dolls](https://en.wikipedia.org/wiki/Matryoshka_doll) with containers?  Why you get containers in containers in containers!  Read all about it with this new article on the Red Hat Developer Blog: [Build and run Buildah inside a Podman container](https://developers.redhat.com/blog/2019/04/04/build-and-run-buildah-inside-a-podman-container/).

--- a/_posts/2019-04-16-new.md
+++ b/_posts/2019-04-16-new.md
@@ -4,5 +4,5 @@ layout: default
 categories: [new]
 ---
 
-What happens when you combine [Matryoshka Dolls](https://en.wikipedia.org/wiki/Matryoshka_doll) with containers?  Why you get containers in containers in containers!  Read all about it with this new article on the [Red Hat Developer Blog](https://developers.redhat.com/blog/): [Build and run Buildah inside a Podman container](https://developers.redhat.com/blog/2019/04/04/build-and-run-buildah-inside-a-podman-container/).
+What happens when you combine [Matryoshka Dolls](https://en.wikipedia.org/wiki/Matryoshka_doll) with containers?  Why you get containers in containers in containers!  Read all about it with this new article on the Red Hat Developer Blog: [Build and run Buildah inside a Podman container](https://developers.redhat.com/blog/2019/04/04/build-and-run-buildah-inside-a-podman-container/).
 


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Link to blog site itself was confusing when viewed.