### PR TITLE
Replace podman logo

### DIFF
--- a/_posts/2019-04-16-cinc.md
+++ b/_posts/2019-04-16-cinc.md
@@ -5,7 +5,7 @@ author: tsweeney
 categories: [blogs]
 tags: containers, images, docker, buildah, podman, oci
 ---
-![podman logo](https://podman.io/images/podman.svg)
+![buildah logo](https://buildah.io/images/buildah.png)
 
 {% assign author = site.authors[page.author] %}
 


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

In the cinc blog, replace Podman logo with Buildah logo.

Third times the charm or strike three, you're out?  