### PR TITLE
Touch up mailinglist home page

### DIFF
--- a/mailinglist/index.html
+++ b/mailinglist/index.html
@@ -3,7 +3,7 @@ layout: default
 title: Buildah Mailing List  
 ---
 
-<img src="https://buildah.io/images/buildah.svg" alt="Buildah logo">
+<img src="https://buildah.io/images/buildah.png" alt="Buildah logo">
 
 <h1>{{ page.title }}</h1>
 
@@ -15,7 +15,8 @@ to subscribe to it.
   <li>Go to this <a href="https://lists.podman.io/admin/lists/buildah.lists.buildah.io/">page</a>, then  scroll down to the bottom of the page and enter your email and optionally name, then click on the "Subscribe" buton.</li>
 </ol>
 
-Regardless of which method you use, a confirmation email will be sent to you.  After you reply back to that confirmation email, you'll then be able to send mail directly to <a href="mailto: buildah@lists.buildah.io">buildah@lists.buildah.io</a>.  You can then also go to the list's [web page](https://lists.podman.io/archives/list/buildah@lists.buildah.io/) and from there you can see all of the past conversations on the list or manage your subscription.
+Regardless of which method you use, a confirmation email will be sent to you.  After you reply back to that confirmation email, you'll then be able to send mail directly to <a href="mailto: buildah@lists.buildah.io">buildah@lists.buildah.io</a>.  You can then also go to the list's <a href="https://lists.podman.io/archives/list/buildah@lists.buildah.io/">web page</a> and from there you can see all of the past conversations on the list or manage your subscription.
 
-<br>
+<p>
 Please note, if you have a bug that you'd like to report, it's best to report them <a href="https://github.com/containers/buildah/issues">here</a> by creating a "New issue" rather than sending an email to the list.
+</p>


### PR DESCRIPTION
I pointed to the wrong image, used a md rather than an html link and used a line break instead of a paragraph break.
This touches up all of the above on the homepage for the mailing list.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>