### PR TITLE
Fix a few tag lines with rogue cr in them

### DIFF
--- a/_posts/2020-08-17-Buildah-on-Kubernetes.md
+++ b/_posts/2020-08-17-Buildah-on-Kubernetes.md
@@ -4,8 +4,7 @@ layout: default
 author: kshirinkin
 categories: [blogs]
 
-tags: community, open source, buildah, skopeo, dive, kubernetes,
-dockerless
+tags: community, open source, buildah, skopeo, dive, kubernetes, dockerless
 ---
 
 # Buildah, Dive, Skopeo&#58; 3 Container Tools for building images on Kubernetes Cluster

--- a/_posts/2020-08-29-reproducible-container-images.md
+++ b/_posts/2020-08-29-reproducible-container-images.md
@@ -4,8 +4,7 @@ layout: default
 author: tsweeney
 categories: [blogs]
 
-tags: community, open source, buildah, skopeo, dive, kubernetes,
-dockerless
+tags: community, open source, buildah, skopeo, dive, kubernetes, dockerless
 ---
 
 # Reproducible Container Images 

--- a/_posts/2021-01-11-getting-started-with-buildah.md
+++ b/_posts/2021-01-11-getting-started-with-buildah.md
@@ -4,8 +4,7 @@ layout: default
 author: tsweeney
 categories: [blogs]
 
-tags: community, open source, buildah, skopeo, dive, kubernetes,
-dockerless
+tags: community, open source, buildah, skopeo, dive, kubernetes, dockerless
 ---
 
 


### PR DESCRIPTION
A few post had two line "tag" lines and it was messing up
the generation of a local server.  This PR removes the
rogue <cr> in each of the three files.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>