### PR TITLE
Fix bullet in 1.21 RA

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,3 +1,3 @@
 ## The buildah.io Project Community Code of Conduct
 
-The buildah.io project follows the [Containers Community Code of Conduct](https://github.com/containers/common/blob/master/CODE-OF-CONDUCT.md).
+The buildah.io project follows the [Containers Community Code of Conduct](https://github.com/containers/common/blob/main/CODE-OF-CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Welcome to the site for [Buildah](https://github.com/projectatomic/buildah/blob/master/README.md). This [site](https://containers.github.io/buildah.io) features announcements and news around Buildah, and occasionally other [container tooling](https://github.com/containers/) news.
 
-![Buildah logo](https://github.com/containers/buildah.io/blob/master/images/buildah.png)
+![Buildah logo](https://github.com/containers/buildah.io/blob/main/images/buildah.png)
 
 ## Website Contributors
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,3 @@
 ## Security and Disclosure Information Policy for the buildah.io Project
 
-The buildah.io Project follows the [Security and Disclosure Information Policy](https://github.com/containers/common/blob/master/SECURITY.md) for the Containers Projects.
+The buildah.io Project follows the [Security and Disclosure Information Policy](https://github.com/containers/common/blob/main/SECURITY.md) for the Containers Projects.

--- a/_posts/2021-06-09-Buildah-version-v1.21.0.md
+++ b/_posts/2021-06-09-Buildah-version-v1.21.0.md
@@ -16,7 +16,7 @@ The Buildah project has continued to grow over the past several weeks, welcoming
 
   * A `--secret` option has been added to the `bud` command, which allows passing secret information (such as a database password) to the Container without it being stored in the final image.  See the `buildah bud` man page for more information.
   *  The `buildah manifest rm` command has been added and allows the user to remove one or more manifest lists.  See the `buildah manifest` and `buildah manifest rm` man pages for more information.
-    * The code that did container image handling has been removed from Buildah and replaced with the new `libimage` package that resides in [containers/common](https://github.com/containers/common/tree/master/libimage).  This code is used by a number of projects in the Containers organization and has proven to be more efficient than the older code. 
+  * The code that did container image handling has been removed from Buildah and replaced with the new `libimage` package that resides in [containers/common](https://github.com/containers/common/tree/master/libimage).  This code is used by a number of projects in the Containers organization and has proven to be more efficient than the older code. 
 
 <!--readmore -->
 


### PR DESCRIPTION
Fix a badly space rogue asterisk in the 1.21 release announcement.
Also touch up a master to main or 3 that we missed.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>