### PR TITLE
Add the Buildah v1.25 Release Announcement

### DIFF
--- a/_posts/2022-01-26-new.md
+++ b/_posts/2022-01-26-new.md
@@ -3,4 +3,4 @@ layout: default
 title: Buildah v1.24.0 Release Announcement
 categories: [new]
 ---
-Buildah v1.24.0 is here with lots of improvements and enhancements.  Check out the [Release Announcement](https://buildah.io/releases/2021/01/26/Buildah-version-v1.24.0.html) for all the details.
+Buildah v1.24.0 is here with lots of improvements and enhancements.  Check out the [Release Announcement](https://buildah.io/releases/2022/01/26/Buildah-version-v1.24.0.html) for all the details.

--- a/_posts/2022-03-29-Buildah-version-v1.25.0.md
+++ b/_posts/2022-03-29-Buildah-version-v1.25.0.md
@@ -1,0 +1,88 @@
+---
+title: Buildah version 1.25.0 Release Announcement
+layout: default
+author: tsweeney
+categories: [releases]
+
+tags: community, open source, buildah, hpc, opensource, containers, images, image
+---
+![buildah logo](https://buildah.io/images/buildah.png)
+
+# Buildah version 1.25.0 Release Announcement
+
+We're pleased to announce the release of [Buildah](https://github.com/containers/buildah) [version 1.25.0](https://github.com/containers/buildah/releases/tag/v1.25.0), which is now available from GitHub for any Linux distro.  We are shipping this release on Fedora 34, and Fedora 35.  Buildah will also be shipped on CentOS, OpenSUSE, and Ubuntu soon.  In addition, container images will be available at https://quay.io/repository/buildah/stable and https://quay.io/repository/containers/buildah.
+
+The Buildah project has continued to grow over the past several weeks, welcoming several new contributors to the mix.  This release features notable enhancements: 
+<!--readmore -->
+ * A container will now wait up to four minutes, up from 5 seconds, when it is created before it will fail due to network issues.
+ * A `--no-hosts` option was added to the `build` and `run` commands.  
+ * A new global option, `--cgroup-manager`, has been added.
+
+This release comprises changes made for v1.24.1, v1.24.2, and v1.25.0 and will be included in Podman v4.1.
+
+## Release Changes
+
+### Changes for v1.25.0
+   * A container will now wait up to four minutes, up from 5 seconds, when it is created before it will fail due to network issues.
+   * A fix for CVE-2022-27651 addressed an issue with inheritable capabilities within the container.
+   * The `--mount=type=cache` option now supports locking the external cache store.
+   * A `--no-hosts` option was added to the `build` and `run` commands.  When used, an `/etc/host` file is not created within the container or container image by default.
+   * Processing was added to the `add` command to ensure the context directory is an absolute path.
+   * During a build, if the base image has a healthconfig and the child image does not, the healthconfig is inherited from the base image.  This emulates the processing that Docker does.
+   * The buildah container images on quay.io now contain cpp.
+   * The subuid/subgid values in buildah container images on quay.io have been increased to 65535.
+
+   * Proxy variables are now only added to the container image’s history only if they are specified with the `ARG` command in the Containerfile.  This emulates Docker’s behavior.
+   * A new option, `--cgroup-manager`, has been added that allows the cgroup manager to be overridden.  More information on the Buildah(1) man page.
+   * When the `--cgroup-manager` is set to systemd, the `--systemd-cgroup` option for the OCI runtime is used, which is understood by both runc and crun.
+   * A build would fail if a `RUN` command was specified in a Containerfile after a `Volume` command.  This [issue](https://github.com/containers/buildah/issues/3281) has been addressed.
+   * An [issue](https://github.com/containers/buildah/issues/3755) with the `run` command’s `--cap-add=all` option not appropriately setting the capabilities has been corrected.
+   * Support has been added for the `FROM` command in a Containerfile to allow specification of the OS, ARCH, or VARIANT values.  See the `--platform` option on the buildah-build (1) man page for more details.
+
+### Overall Miscellaneous Changes  
+* Documentation:
+   * The source files for the Containerfile and containeringore man pages have moved to the containers/common project.
+   * The options for commands in the man pages are now sorted alphabetically.
+   * Removed references to Kubic for CentOS and Ubuntu on the installation guide. 
+
+* Vendored:
+   * Vendor in github.com/containerd/containerd from v1.6.2
+   * Vendor in github.com/containers/common to v0.47.5
+   * Vendor in github.com/containers/image/v5 v5.20.0
+   * Vendor in github.com/containers/ocicrypt v1.1.3
+   * Vendor in github.com/containers/storage v1.39.0
+   * Vendor in github.com/docker/distribution v2.8.1
+   * Vendor in github.com/docker/docker v20.10.14
+   * Vendor in github.com/fsouza/go-dockerclient v1.7.10
+   * Vendor in github.com/onsi/gomega v1.18.1
+   * Vendor in openshift/imagebuilder v1.2.2
+   * Vendor in github.com/prometheus/client_golang to v1.11.1
+   * Vendor in github.com/spf13/cobra v1.4.0
+   * Vendor in github.com/stretchr/testify v1.7.1
+
+* Tests:
+   * Add a few "replace-directory-with-symlink" tests in the conformance tests.
+   * Removed a number of skips for rootless users.
+   * Now unshares mount/umount if test is_rootless.
+   * The copy tests now read the correct containers.conf and initialize the network.
+   * Tests for rootless, which need unshare.
+   * Added a test to protect against CVE-2022-27651 in the future.
+   * The integration tests now run in a rootless environment.
+   * An issue between TESTDIR and TESTSDIR in the test environment was fixed.
+   * The combination-namespaces test has been sped up.
+   * Tests now print a full pathname for files to output.
+
+* Changes to the build infrastructure:
+   * Cirrus: Use updated VM images.
+   * Makefile: build with systemd when available.
+   * Cirrus: added a separate task and matrix for rootless.
+
+* Plus several minor fixes.
+
+## Try it Out.
+ 
+If you haven’t yet, [install Buildah](https://github.com/containers/buildah/blob/master/install.md) from one of the Linux repos or GitHub and give it a spin.  We’re betting you'll find it’s an easy and quick way to build containers in your environment without a daemon being involved!
+
+For those of you who contributed to this release, thank you very much for your contributions!  If you haven't joined our community yet, don't wait any longer!  Come join us on GitHub, where Open Source communities live.
+
+## Buildah == Simplicity

--- a/_posts/2022-03-29-new.md
+++ b/_posts/2022-03-29-new.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Buildah v1.25.0 Release Announcement
+categories: [new]
+---
+Buildah v1.25.0 is here with lots of improvements and enhancements.  Check out the [Release Announcement](https://buildah.io/releases/2022/03/29/Buildah-version-v1.25.0.html) for all the details.


### PR DESCRIPTION
As the title says.  Trying to catch up with all of the release announcements.

I also spotted a bad link in the v1.24 new page, touched that up too.

Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>