### PR TITLE
Fix link to 1.31 release announcement

### DIFF
--- a/_posts/2023-07-21-new.md
+++ b/_posts/2023-07-21-new.md
@@ -3,4 +3,4 @@ layout: default
 title: Buildah v1.31.0 Release Announcement
 categories: [new]
 ---
-Buildah v1.31.0 is here with lots of improvements and enhancements.  Check out the [Release Announcement](https://buildah.io/releases/2023/04/21/Buildah-version-v1.31.0.html).
+Buildah v1.31.0 is here with lots of improvements and enhancements.  Check out the [Release Announcement](https://buildah.io/releases/2023/07/21/Buildah-version-v1.31.0.html).


### PR DESCRIPTION
The home page talks about 1.31, but the link to the full announcement is broken.

Related to #109