### PR TITLE
Fix bad link to 1.32 RA

### DIFF
--- a/_posts/2023-10-03-new.md
+++ b/_posts/2023-10-03-new.md
@@ -3,4 +3,4 @@ layout: default
 title: Buildah v1.32.0 Release Announcement
 categories: [new]
 ---
-Buildah v1.32.0 is here with lots of improvements and enhancements.  Check out the [Release Announcement](https://buildah.io/releases/2023/10/02/Buildah-version-v1.32.0.html).
+Buildah v1.32.0 is here with lots of improvements and enhancements.  Check out the [Release Announcement](https://buildah.io/releases/2023/10/03/Buildah-version-v1.32.0.html).


### PR DESCRIPTION
The link to the v1.32 Release Announcement was pointing to a file created on 2023-10-02 when it should have been pointing to a file created on 2023-10-03.  This corrects that typo.