### PR TITLE
Fix Buildah v1.39 new page

### DIFF
--- a/_posts/2025-02-03-new.md
+++ b/_posts/2025-02-03-new.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Buildah v1.38.0 Release Announcement
+title: Buildah v1.39.0 Release Announcement
 categories: [new]
 ---
-Buildah v1.38.0 is here with lots of improvements and enhancements.  Check out the [Release Announcement](https://buildah.io/releases/2024/11/11/Buildah-version-v1.38.0.html).
+Buildah v1.39.0 is here with lots of improvements and enhancements.  Check out the [Release Announcement](https://buildah.io/releases/2025/02/03/Buildah-version-v1.39.0.html).


### PR DESCRIPTION
The new page for Buildah v1.39 pointed at the v1.38 page instead.   This
fixes that.