### PR TITLE
Remove Google Analytics

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,15 +1,6 @@
 <!doctype html>
 <html lang="{{ site.lang | default: "en-US" }}">
   <head>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-132755160-2"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-    
-      gtag('config', 'UA-132755160-2');
-    </script>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta property="og:url" content="https://buildah.io">


### PR DESCRIPTION
This will remove Google Analytics from the site.  We have been collecting information for quite a while, but not analyzing it at all.  Time to turn the spigot off.